### PR TITLE
Fix publishing.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/scripts/publish-mavencentral
+++ b/scripts/publish-mavencentral
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Publish to Maven
-sbt "+publish-signed"
+sbt "publish-signed"


### PR DESCRIPTION
Previously, publishing was set up to rely on sbt plugins installed globally.
Instead, we should install all plugins required explicitly, without relying on
implicit globals.

Additionally, we rely on dependencies that only work on Java 1.8, and Scala 2.11
so we will only publish Scala 2.11+.
