### PR TITLE
Add unimplemented reads

### DIFF
--- a/courscala/src/main/scala/org/coursera/common/stringkey/StringKeyFormat.scala
+++ b/courscala/src/main/scala/org/coursera/common/stringkey/StringKeyFormat.scala
@@ -150,6 +150,12 @@ object StringKeyFormat extends CommonStringKeyFormats {
       key => StringKey((prefix, key)))
   }
 
+  def unimplementedFormat[T]: StringKeyFormat[T] = {
+    StringKeyFormat(
+      _ => None,
+      _ => throw new UnsupportedOperationException("Writes not implemented"))
+  }
+
   object Implicits {
 
     implicit class OrFormat[T](baseFormat: StringKeyFormat[T]) {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.7"
+version in ThisBuild := "0.0.8"


### PR DESCRIPTION
The StringKeyFormat.unimplementedFormat is important for using the orReads
helpers, etc.
