### PR TITLE
Add StringKeyFormats.typedEmptyStringFormat

### DIFF
--- a/courscala/src/main/scala/org/coursera/common/stringkey/StringKeyFormat.scala
+++ b/courscala/src/main/scala/org/coursera/common/stringkey/StringKeyFormat.scala
@@ -150,6 +150,21 @@ object StringKeyFormat extends CommonStringKeyFormats {
       key => StringKey((prefix, key)))
   }
 
+  /**
+   * Useful for defining a StringKeyFormat for empty case classes or case objects based on some
+   * constant string. Should NEVER be used for non-empty case classes.
+   *
+   * Given a `typeName` and a `canonical` representation of the object, will map
+   * StringKey(typeName) <==> `canonical`
+   */
+  def typedEmptyStringFormat[T](
+      typeName: String,
+      canonical: => T): StringKeyFormat[T] = {
+    StringKeyFormat(
+      _.asOpt[String].filter(_ == typeName).map(_ => canonical),
+      _ => StringKey(typeName))
+  }
+
   def unimplementedFormat[T]: StringKeyFormat[T] = {
     StringKeyFormat(
       _ => None,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.8"
+version in ThisBuild := "0.0.9"


### PR DESCRIPTION
This format is useful when defining a string key format for case objects.
