### PR TITLE
Add Seq & Set StringKeyFormats

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.11"
+version in ThisBuild := "0.0.12"


### PR DESCRIPTION
Seq and Set StringKeyFormats are important for query parameter parsing in
Naptime.
