### PR TITLE
Fix NPE in `StringKey`'s `StringKeyFormat`

### DIFF
--- a/courscala/src/main/scala/org/coursera/common/stringkey/StringKeyFormat.scala
+++ b/courscala/src/main/scala/org/coursera/common/stringkey/StringKeyFormat.scala
@@ -54,8 +54,7 @@ trait StringKeyFormat[T] {
 
 object StringKeyFormat extends CommonStringKeyFormats {
 
-  implicit val stringKeyStringKeyFormat: StringKeyFormat[StringKey] =
-    delegateFormat[StringKey, StringKey](key => Some(key), identity _)
+  implicit val stringKeyStringKeyFormat: StringKeyFormat[StringKey] = apply(Some(_), identity)
 
   def apply[T](from: StringKey => Option[T], to: T => StringKey): StringKeyFormat[T] = {
     new StringKeyFormat[T] {

--- a/courscala/src/test/scala/org/coursera/common/stringkey/StringKeyFormatTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/stringkey/StringKeyFormatTest.scala
@@ -28,6 +28,17 @@ class StringKeyFormatTest extends AssertionsForJUnit {
   import StringKeyFormatTest._
 
   @Test
+  def testStringKeyRead(): Unit = {
+    assert(Some(StringKey("test")) ===
+      StringKeyFormat.stringKeyStringKeyFormat.reads(StringKey("test")))
+  }
+
+  @Test
+  def testStringKeyWrite(): Unit = {
+    assert(StringKey("test") === StringKeyFormat.stringKeyStringKeyFormat.writes(StringKey("test")))
+  }
+
+  @Test
   def testPrefixWrite(): Unit = {
     val format = StringKeyFormat.prefixFormat[String]("pre", implicitly[StringKeyFormat[String]])
     assert(format.writes("hello") === StringKey("pre~hello"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.12"
+version in ThisBuild := "0.0.13"


### PR DESCRIPTION
@bryan-coursera 

This seems like an initialization order problem. We didn't have tests before, presumably because it seemed obvious. Alas, it was not.

Old test output:
```text
> courscala/testOnly *StringKeyFormatTest
[info] Compiling 1 Scala source to /Users/josh/base/coursera/courscala/courscala/target/scala-2.11/classes...
[info] Compiling 1 Scala source to /Users/josh/base/coursera/courscala/courscala/target/scala-2.11/test-classes...
[info] Test run started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple3ReadSimple started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testPrefixRead started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testPrefixReadFail started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple2ReadSimple started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.enum started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testUuidFormat started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple2WriteSimple started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testEmptyFormat started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple3WriteSimple started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple2WriteEscaped started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testPrefixWrite started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple2ReadEscaped started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.nestedTuples started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.separatorIsLiteralNotRegex started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testStringKeyRead started
[error] Test org.coursera.common.stringkey.StringKeyFormatTest.testStringKeyRead failed: java.lang.NullPointerException: null, took 0.002 sec
[error]     at org.coursera.common.stringkey.StringKeyFormat$$anonfun$delegateFormat$1.apply(StringKeyFormat.scala:74)
[error]     at org.coursera.common.stringkey.StringKeyFormat$$anonfun$delegateFormat$1.apply(StringKeyFormat.scala:74)
[error]     at org.coursera.common.stringkey.StringKeyFormat$$anon$1.reads(StringKeyFormat.scala:62)
[error]     at org.coursera.common.stringkey.StringKeyFormatTest.testStringKeyRead(StringKeyFormatTest.scala:33)
[error]     ...
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.separatorIsLiteralNotRegexAndExcapedProperly started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testStringKeyWrite started
[error] Test org.coursera.common.stringkey.StringKeyFormatTest.testStringKeyWrite failed: java.lang.NullPointerException: null, took 0.002 sec
[error]     at org.coursera.common.stringkey.StringKeyFormat$$anonfun$delegateFormat$2.apply(StringKeyFormat.scala:74)
[error]     at org.coursera.common.stringkey.StringKeyFormat$$anonfun$delegateFormat$2.apply(StringKeyFormat.scala:74)
[error]     at org.coursera.common.stringkey.StringKeyFormat$$anon$1.writes(StringKeyFormat.scala:63)
[error]     at org.coursera.common.stringkey.StringKeyFormatTest.testStringKeyWrite(StringKeyFormatTest.scala:38)
[error]     ...
[info] Test run finished: 2 failed, 0 ignored, 17 total, 0.184s
[error] Failed: Total 17, Failed 2, Errors 0, Passed 15
[error] Failed tests:
[error]         org.coursera.common.stringkey.StringKeyFormatTest
[error] (courscala/test:testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 4 s, completed Nov 1, 2016 6:00:26 PM
```

New test output:
```
> courscala/testOnly *StringKeyFormatTest
[info] Compiling 1 Scala source to /Users/josh/base/coursera/courscala/courscala/target/scala-2.11/classes...
[info] Test run started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple3ReadSimple started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testPrefixRead started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testPrefixReadFail started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple2ReadSimple started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.enum started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testUuidFormat started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple2WriteSimple started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testEmptyFormat started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple3WriteSimple started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple2WriteEscaped started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testPrefixWrite started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testTuple2ReadEscaped started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.nestedTuples started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.separatorIsLiteralNotRegex started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testStringKeyRead started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.separatorIsLiteralNotRegexAndExcapedProperly started
[info] Test org.coursera.common.stringkey.StringKeyFormatTest.testStringKeyWrite started
[info] Test run finished: 0 failed, 0 ignored, 17 total, 0.127s
[info] Passed: Total 17, Failed 0, Errors 0, Passed 17
[success] Total time: 3 s, completed Nov 1, 2016 6:00:35 PM
```