### PR TITLE
Bump version to reflect previous change

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,8 +21,8 @@ import sbt._
 
 object Courscala extends Build with OverridablePublishSettings {
 
-  val currentScalaVersion = "2.11.6"
-  val supportedScalaVersions = Seq("2.10.5", currentScalaVersion)
+  val currentScalaVersion = "2.11.8"
+  val supportedScalaVersions = Seq("2.11.6", currentScalaVersion)
 
   override lazy val settings = super.settings ++ overridePublishSettings ++
     Seq(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.13"
+version in ThisBuild := "0.0.14"


### PR DESCRIPTION
I forgot to (/didn't know to) bump the package version to in the earlier PR I merged (https://github.com/coursera/courscala/pull/14). 

I think `2.10.5` as a supported scala version is a lie and no one has built courscala for it recently. When I tried to, it complained about our use of `Future.fromTry` which does not exist in `2.10` (https://github.com/scala/scala/blob/v2.10.0/src/library/scala/concurrent/Future.scala).