### PR TITLE
Update play-json to 2.6.2

### DIFF
--- a/courscala/build.sbt
+++ b/courscala/build.sbt
@@ -4,6 +4,7 @@ name := "courscala"
 
 libraryDependencies ++= Seq(
   PlayJson.playJson,
+  PlayJsonJoda.playJsonJoda,
   JUnitInterface.junitInterface,
   Scalatest.scalatest)
 

--- a/courscala/src/main/scala/org/coursera/common/jsonformat/JsonFormats.scala
+++ b/courscala/src/main/scala/org/coursera/common/jsonformat/JsonFormats.scala
@@ -20,9 +20,12 @@ import org.coursera.common.collection.Enum
 import org.coursera.common.collection.EnumSymbol
 import org.coursera.common.stringkey.StringKey
 import org.coursera.common.stringkey.StringKeyFormat
+import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.joda.time.Instant
 import play.api.libs.json.Format
+import play.api.libs.json.JodaReads
+import play.api.libs.json.JodaWrites
 import play.api.libs.json.JsError
 import play.api.libs.json.JsObject
 import play.api.libs.json.JsResult
@@ -177,6 +180,10 @@ object JsonFormats {
         millis => new Instant(millis),
         instant => instant.getMillis)
     }
+
+    implicit val dateTimeFormat: Format[DateTime] = Format(
+      JodaReads.DefaultJodaDateTimeReads,
+      JodaWrites.JodaDateTimeNumberWrites)
 
     implicit def mapReads[K, V](implicit keyFormat: StringKeyFormat[K], valueReads: Reads[V]):
       Reads[Map[K, V]] = {

--- a/courscala/src/test/scala/org/coursera/common/jsonformat/JsonFormatsTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/jsonformat/JsonFormatsTest.scala
@@ -72,6 +72,7 @@ class JsonFormatsTest extends AssertionsForJUnit {
 
   @Test
   def dateTime(): Unit = {
+    import JsonFormats.Implicits.dateTimeFormat
     val testDatetime = new DateTime(2010, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC)
     assertResult(JsNumber(1262304000000L))(Json.toJson(testDatetime))
     assertResult(Some(testDatetime))(Json.parse("1262304000000").asOpt[DateTime].map(_.withZone(DateTimeZone.UTC)))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,8 +21,8 @@ import sbt._
 
 object Courscala extends Build with OverridablePublishSettings {
 
-  val currentScalaVersion = "2.11.8"
-  val supportedScalaVersions = Seq("2.11.6", currentScalaVersion)
+  val currentScalaVersion = "2.11.11"
+  val supportedScalaVersions = Seq(currentScalaVersion)
 
   override lazy val settings = super.settings ++ overridePublishSettings ++
     Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,8 +25,13 @@ object Dependencies {
   }
 
   object PlayJson {
-    val version = "2.4.4"
+    val version = "2.6.2"
     val playJson = "com.typesafe.play" %% "play-json" % version
+  }
+
+  object PlayJsonJoda {
+    val version = "2.6.2"
+    val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % version
   }
 
   object Scalatest {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ import Keys._
 object Dependencies {
 
   object Scala {
-    val version = "2.11.6"
+    val version = "2.11.11"
     val scalaReflect = "org.scala-lang" % "scala-reflect" % version
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-sbt.version=0.13.9
+sbt.version=0.13.15


### PR DESCRIPTION
The default `Format` for `org.joda.time.DateTime`, has been removed from `play-json` 2.6, so we define our own in `org.coursera.common.jsonformat.JsonFormat.Implicit.dateTimeFormat`.