### PR TITLE
Cross build for Scala 2.10.6

### DIFF
--- a/courscala/build.sbt
+++ b/courscala/build.sbt
@@ -5,8 +5,11 @@ name := "courscala"
 libraryDependencies ++= Seq(
   PlayJson.playJson,
   PlayJsonJoda.playJsonJoda,
+  JodaTime.jodaTime,
+  JodaConvert.jodaConvert,
   JUnitInterface.junitInterface,
-  Scalatest.scalatest)
+  Scalatest.scalatest,
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value)
 
 testFrameworks := Seq(sbt.TestFrameworks.JUnit)
 

--- a/courscala/src/main/scala/org/coursera/common/concurrent/Futures.scala
+++ b/courscala/src/main/scala/org/coursera/common/concurrent/Futures.scala
@@ -18,9 +18,11 @@ package org.coursera.common.concurrent
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+import scala.util.control.NonFatal
 
 object Futures extends FutureExtractors {
 
@@ -29,7 +31,14 @@ object Futures extends FutureExtractors {
    *
    * Returns a successful future if `f` completes or a failed one if `f` throws an exception.
    */
-  def immediate[T](f: => T): Future[T] = Future.fromTry(Try(f))
+  def immediate[T](f: => T): Future[T] = {
+    try {
+      Future.successful(f)
+    } catch {
+      case NonFatal(e) =>
+        Future.failed(e)
+    }
+  }
 
   /**
    * Executes `f` immediately. Returns `f`'s future (either successful or not) if `f` completes

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,8 +21,8 @@ import sbt._
 
 object Courscala extends Build with OverridablePublishSettings {
 
-  val currentScalaVersion = "2.11.11"
-  val supportedScalaVersions = Seq(currentScalaVersion, "2.12.4")
+  val currentScalaVersion = "2.12.4"
+  val supportedScalaVersions = Seq("2.10.6", "2.11.11", currentScalaVersion)
 
   override lazy val settings = super.settings ++ overridePublishSettings ++
     Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,20 +18,24 @@ import sbt._
 import Keys._
 
 object Dependencies {
-
-  object Scala {
-    val version = "2.11.11"
-    val scalaReflect = "org.scala-lang" % "scala-reflect" % version
-  }
-
   object PlayJson {
-    val version = "2.6.2"
+    val version = "2.6.7"
     val playJson = "com.typesafe.play" %% "play-json" % version
   }
 
   object PlayJsonJoda {
-    val version = "2.6.2"
+    val version = "2.6.7"
     val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % version
+  }
+
+  object JodaTime {
+    val version = "2.9.9"
+    val jodaTime = "joda-time" % "joda-time" % version
+  }
+
+  object JodaConvert {
+    val version = "1.9.2"
+    val jodaConvert = "org.joda" % "joda-convert" % version
   }
 
   object Scalatest {


### PR DESCRIPTION
- Add Scala 2.10.6 to cross-build versions
- Set current Scala version to 2.12.4
- Add missing joda-time and joda-convert dependencies
- Use the correct version number for org.scala-lang.scala-reflect dependency
