### PR TITLE
Add default to Enum trait

### DIFF
--- a/courscala/src/main/scala/org/coursera/common/collection/Enum.scala
+++ b/courscala/src/main/scala/org/coursera/common/collection/Enum.scala
@@ -94,8 +94,17 @@ trait Enum[SymbolType <: EnumSymbol] { self =>
    * @throws NoSuchElementException if no enum symbol is found for the given name
    */
   def withName(name: String): SymbolType = {
-    byName.getOrElse(name, throw new NoSuchElementException(s"No value found for '$name'"))
+    byName
+      .get(name)
+      .orElse(defaultValue)
+      .getOrElse(throw new NoSuchElementException(s"No value found for '$name'"))
   }
+
+  /**
+   * Override to provide a default value when [[withName()]] is called and no element is found
+   * @return
+   */
+  protected def defaultValue: Option[SymbolType] = None
 }
 
 /**

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.3"
+version in ThisBuild := "0.1.4"


### PR DESCRIPTION
When using `AliasEnumSymbol` we don't currently have a straightforward way of setting the default/unknown value.

I've seen:

```
  override def withName(s: String): T = {
    symbols.find(_.toString == s).getOrElse($UNKNOWN)
  }
```

But I think it would be nice to simply be able to define the default value directly:

```
  override protected def defaultValue: Option[T] = Some($UNKNOWN)
```