### PR TITLE
convert stringKey read exception to `None`

### DIFF
--- a/courscala/src/main/scala/org/coursera/common/stringkey/StringKeyFormat.scala
+++ b/courscala/src/main/scala/org/coursera/common/stringkey/StringKeyFormat.scala
@@ -90,7 +90,7 @@ object StringKeyFormat extends CommonStringKeyFormats {
       apply: U => T,
       unapply: T => Option[U])
       (implicit otherFormat: StringKeyFormat[U]): StringKeyFormat[T] = {
-    delegateFormat[T, U](apply.andThen(Some.apply), unapply.andThen(_.get))
+    delegateFormat[T, U](u => Try(apply(u)).toOption, unapply.andThen(_.get))
   }
 
   def enumerationFormat(enumeration: Enumeration): StringKeyFormat[enumeration.Value] = {

--- a/courscala/src/test/scala/org/coursera/common/stringkey/StringKeyFormatTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/stringkey/StringKeyFormatTest.scala
@@ -167,6 +167,27 @@ class StringKeyFormatTest extends AssertionsForJUnit {
     assert(decoded.get === uuid1)
   }
 
+  @Test
+  def read_caseClassFormat_validReturns_Some(): Unit = {
+    assertResult(Some(TestId("aBaC9"))) {
+      new StringKey("aBaC9").asOpt[TestId]
+    }
+  }
+
+  @Test
+  def read_caseClassFormat_invalidReturns_None(): Unit = {
+    assertResult(None) {
+      new StringKey("").asOpt[TestId]
+    }
+  }
+
+  @Test
+  def write_caseClassFormat_writesId(): Unit = {
+
+    assertResult("aBaC9") {
+      StringKey.stringify(new TestId("aBaC9"))
+    }
+  }
 }
 
 object StringKeyFormatTest {
@@ -184,6 +205,15 @@ object StringKeyFormatTest {
     case object Green extends Color
 
     implicit val stringKeyFormat: StringKeyFormat[Color] = StringKeyFormat.enumFormat(Color)
+
+  }
+
+  case class TestId(value: String) {
+    require(value.nonEmpty, "value must be non-empty")
+  }
+
+  object TestId {
+    implicit val stringKeyFormat: StringKeyFormat[TestId] = StringKeyFormat.caseClassFormat(apply, unapply)
   }
 
 }


### PR DESCRIPTION
For whatever reason when we read optional values for other formats like enumerations we will convert exceptions to `None`. 

But for our case classes, we have neglected to do so. This exceptional result causes our naptime request handler to throw a 5XX instead of a 4XX when parsing certain kinds of bad values.

I believe this has gone unnoticed because it seems to only cause problems in rare circumstances where we have an additional "require" validation statement in the case class constructor.

See https://github.com/webedx-spark/infra-services/pull/18424

I believe semantically returning `None` is the correct behavior in this circumstance because the string can not be parsed as a valid key.