### PR TITLE
Increase test coverage: add tests for key modules

### DIFF
--- a/courscala/build.sbt
+++ b/courscala/build.sbt
@@ -9,6 +9,7 @@ libraryDependencies ++= Seq(
   JodaConvert.jodaConvert,
   JUnitInterface.junitInterface,
   Scalatest.scalatest,
+  ScalatestPlusJUnit.scalatestPlusJunit,
   "org.scala-lang" % "scala-reflect" % scalaVersion.value)
 
 testFrameworks := Seq(sbt.TestFrameworks.JUnit)

--- a/courscala/src/test/scala/org/coursera/common/collection/EnumTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/collection/EnumTest.scala
@@ -19,7 +19,7 @@ package org.coursera.common.collection
 import org.coursera.common.collection
 import org.coursera.common.collection.Container.Direction
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 import scala.collection.immutable.SortedSet
 
@@ -70,6 +70,12 @@ class EnumTest extends AssertionsForJUnit {
 
     assertResult(Indexed.One.id)(1)
     assertResult(Indexed(1))(Indexed.One)
+  }
+
+  @Test
+  def defaultValue(): Unit = {
+    assertResult(ColorWithDefault.Unknown)(ColorWithDefault.withName("nonexistent"))
+    assertResult(ColorWithDefault.Red)(ColorWithDefault.withName("Red"))
   }
 
   @Test
@@ -137,4 +143,12 @@ sealed abstract class AliasedIndexed(id: Int, name: String)
 object AliasedIndexed extends IndexedEnum[AliasedIndexed] {
   case object Zero extends AliasedIndexed(0, "zero")
   case object One extends AliasedIndexed(1, "one")
+}
+
+sealed trait ColorWithDefault extends EnumSymbol
+
+object ColorWithDefault extends collection.Enum[ColorWithDefault] {
+  case object Red extends ColorWithDefault
+  case object Unknown extends ColorWithDefault
+  override protected def defaultValue: Option[ColorWithDefault] = Some(Unknown)
 }

--- a/courscala/src/test/scala/org/coursera/common/concurrent/FutureExtractorsTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/concurrent/FutureExtractorsTest.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2024 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.common.concurrent
+
+import org.junit.Test
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.Millis
+import org.scalatest.time.Seconds
+import org.scalatest.time.Span
+import org.scalatestplus.junit.AssertionsForJUnit
+
+import scala.concurrent.Future
+
+/**
+ * Tests for [[FutureExtractors]] arities 4 through 22.
+ *
+ * Arities 2 and 3 are already covered by [[FuturesTest]].
+ * Each test calls `Futures.Extract(...)` in a pattern-match to exercise the
+ * corresponding `unapply` overload, which is the primary coverage gap.
+ */
+class FutureExtractorsTest extends AssertionsForJUnit with ScalaFutures {
+
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(2, Seconds)), interval = scaled(Span(20, Millis)))
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  @Test
+  def extract_tuple4(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4) = Futures.immediate((1, "a", true, 2.0))
+    assertResult(1)(f1.futureValue)
+    assertResult("a")(f2.futureValue)
+    assertResult(true)(f3.futureValue)
+    assertResult(2.0)(f4.futureValue)
+  }
+
+  @Test
+  def extract_tuple5(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5) = Futures.immediate((1, 2, 3, 4, 5))
+    assertResult(1)(f1.futureValue)
+    assertResult(2)(f2.futureValue)
+    assertResult(3)(f3.futureValue)
+    assertResult(4)(f4.futureValue)
+    assertResult(5)(f5.futureValue)
+  }
+
+  @Test
+  def extract_tuple6(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6) = Futures.immediate((1, 2, 3, 4, 5, 6))
+    assertResult(1)(f1.futureValue)
+    assertResult(6)(f6.futureValue)
+  }
+
+  @Test
+  def extract_tuple7(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7) = Futures.immediate((1, 2, 3, 4, 5, 6, 7))
+    assertResult(1)(f1.futureValue)
+    assertResult(7)(f7.futureValue)
+  }
+
+  @Test
+  def extract_tuple8(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8) = Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8))
+    assertResult(1)(f1.futureValue)
+    assertResult(8)(f8.futureValue)
+  }
+
+  @Test
+  def extract_tuple9(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9) = Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9))
+    assertResult(1)(f1.futureValue)
+    assertResult(9)(f9.futureValue)
+  }
+
+  @Test
+  def extract_tuple10(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    assertResult(1)(f1.futureValue)
+    assertResult(10)(f10.futureValue)
+  }
+
+  @Test
+  def extract_tuple11(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+    assertResult(1)(f1.futureValue)
+    assertResult(11)(f11.futureValue)
+  }
+
+  @Test
+  def extract_tuple12(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+    assertResult(1)(f1.futureValue)
+    assertResult(12)(f12.futureValue)
+  }
+
+  @Test
+  def extract_tuple13(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13))
+    assertResult(1)(f1.futureValue)
+    assertResult(13)(f13.futureValue)
+  }
+
+  @Test
+  def extract_tuple14(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14))
+    assertResult(1)(f1.futureValue)
+    assertResult(14)(f14.futureValue)
+  }
+
+  @Test
+  def extract_tuple15(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+    assertResult(1)(f1.futureValue)
+    assertResult(15)(f15.futureValue)
+  }
+
+  @Test
+  def extract_tuple16(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+    assertResult(1)(f1.futureValue)
+    assertResult(16)(f16.futureValue)
+  }
+
+  @Test
+  def extract_tuple17(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17))
+    assertResult(1)(f1.futureValue)
+    assertResult(17)(f17.futureValue)
+  }
+
+  @Test
+  def extract_tuple18(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18))
+    assertResult(1)(f1.futureValue)
+    assertResult(18)(f18.futureValue)
+  }
+
+  @Test
+  def extract_tuple19(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19))
+    assertResult(1)(f1.futureValue)
+    assertResult(19)(f19.futureValue)
+  }
+
+  @Test
+  def extract_tuple20(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20))
+    assertResult(1)(f1.futureValue)
+    assertResult(20)(f20.futureValue)
+  }
+
+  @Test
+  def extract_tuple21(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21))
+    assertResult(1)(f1.futureValue)
+    assertResult(21)(f21.futureValue)
+  }
+
+  @Test
+  def extract_tuple22(): Unit = {
+    val Futures.Extract(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22) =
+      Futures.immediate((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22))
+    assertResult(1)(f1.futureValue)
+    assertResult(22)(f22.futureValue)
+  }
+
+  @Test
+  def extract_tuple4_failedFuture_propagatesToAllComponents(): Unit = {
+    val ex = new RuntimeException("upstream failure")
+    val failed = Future.failed[(Int, String, Boolean, Double)](ex)
+    val Futures.Extract(f1, f2, f3, f4) = failed
+    assertResult(ex)(f1.failed.futureValue)
+    assertResult(ex)(f4.failed.futureValue)
+  }
+}

--- a/courscala/src/test/scala/org/coursera/common/concurrent/FuturesTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/concurrent/FuturesTest.scala
@@ -18,16 +18,18 @@ package org.coursera.common.concurrent
 
 import org.junit.Test
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatest.time.Millis
 import org.scalatest.time.Seconds
 import org.scalatest.time.Span
 
 import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
 
 class FuturesTest extends AssertionsForJUnit with ScalaFutures {
 
-  implicit override val patienceConfig =
+  implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(1, Seconds)), interval = scaled(Span(20, Millis)))
 
   import scala.concurrent.ExecutionContext.Implicits.global
@@ -46,6 +48,79 @@ class FuturesTest extends AssertionsForJUnit with ScalaFutures {
 
     assertResult(1)(future1.futureValue)
     assertResult(2)(future2.futureValue)
+  }
+
+  @Test
+  def extract_tuple3(): Unit = {
+    val Futures.Extract(f1, f2, f3) = Futures.immediate((1, "hello", true))
+    assertResult(1)(f1.futureValue)
+    assertResult("hello")(f2.futureValue)
+    assertResult(true)(f3.futureValue)
+  }
+
+  @Test
+  def immediate_success(): Unit = {
+    assertResult(42)(Futures.immediate(42).futureValue)
+  }
+
+  @Test
+  def immediate_exception(): Unit = {
+    val ex = new RuntimeException("boom")
+    val fut = Futures.immediate[Int](throw ex)
+    assertResult(ex)(fut.failed.futureValue)
+  }
+
+  @Test
+  def safelyCall_success(): Unit = {
+    assertResult(1)(Futures.safelyCall(Future.successful(1)).futureValue)
+  }
+
+  @Test
+  def safelyCall_exception(): Unit = {
+    val ex = new RuntimeException("boom")
+    val fut = Futures.safelyCall[Int](throw ex)
+    assertResult(ex)(fut.failed.futureValue)
+  }
+
+  @Test
+  def findMatch_found(): Unit = {
+    val futures = List(Future.successful("hello"), Future.successful("world"))
+    val result = Futures.findMatch(futures) { case s if s.startsWith("w") => s.length }
+    assertResult(Some(5))(result.futureValue)
+  }
+
+  @Test
+  def findMatch_notFound(): Unit = {
+    val futures = List(Future.successful("hello"), Future.successful("world"))
+    val result = Futures.findMatch(futures) { case s if s.startsWith("z") => s.length }
+    assertResult(None)(result.futureValue)
+  }
+
+  @Test
+  def option_some(): Unit = {
+    val result = Futures.option(Some(Future.successful(42)))
+    assertResult(Some(42))(result.futureValue)
+  }
+
+  @Test
+  def option_none(): Unit = {
+    val result = Futures.option(None: Option[Future[Int]])
+    assertResult(None)(result.futureValue)
+  }
+
+  @Test
+  def toTry_success(): Unit = {
+    import Futures.Implicits._
+    val result = Future.successful(42).toTry
+    assertResult(Success(42))(result.futureValue)
+  }
+
+  @Test
+  def toTry_failure(): Unit = {
+    import Futures.Implicits._
+    val ex = new RuntimeException("boom")
+    val result = Future.failed[Int](ex).toTry
+    assertResult(Failure(ex))(result.futureValue)
   }
 
 }

--- a/courscala/src/test/scala/org/coursera/common/jsonformat/CopyingFormatsTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/jsonformat/CopyingFormatsTest.scala
@@ -17,9 +17,10 @@
 package org.coursera.common.jsonformat
 
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import play.api.libs.json.JsSuccess
 import play.api.libs.json.Json
+import play.api.libs.json.OFormat
 import play.api.libs.json.Reads
 
 class CopyingFormatsTest extends AssertionsForJUnit {
@@ -37,6 +38,24 @@ class CopyingFormatsTest extends AssertionsForJUnit {
   def readOld(): Unit = {
     assertResult(JsSuccess(NewType("", "", 1))) {
       Json.fromJson[NewType](Json.obj("oldField" -> "", "unrelated" -> 1))
+    }
+  }
+
+  @Test
+  def copyingFormat_writes(): Unit = {
+    val fmt = CopyingFormats.copyingFormat(Json.format[NewType], "oldField" -> "newField")
+    val obj = NewType("hi", "old", 1)
+    assertResult(Json.toJson(obj)(Json.writes[NewType]))(fmt.writes(obj))
+  }
+
+  @Test
+  def copyingOFormat_roundtrip(): Unit = {
+    val fmt: OFormat[NewType] = CopyingFormats.copyingOFormat(Json.format[NewType], "oldField" -> "newField")
+    assertResult(JsSuccess(NewType("hi", "", 1))) {
+      fmt.reads(Json.obj("newField" -> "hi", "oldField" -> "", "unrelated" -> 1))
+    }
+    assertResult(JsSuccess(NewType("", "", 1))) {
+      fmt.reads(Json.obj("oldField" -> "", "unrelated" -> 1))
     }
   }
 

--- a/courscala/src/test/scala/org/coursera/common/jsonformat/FlatTypedFormatsTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/jsonformat/FlatTypedFormatsTest.scala
@@ -17,7 +17,7 @@
 package org.coursera.common.jsonformat
 
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
@@ -46,6 +46,39 @@ class FlatTypedFormatsTest extends AssertionsForJUnit {
     assertResult(expectedJs)(writes.writes(T1(1)))
   }
 
+  @Test
+  def flatTypedDefinitionFormat_roundtrip(): Unit = {
+    // Exercises the combined OFormat entry point (flatTypedDefinitionFormat) which was
+    // previously at 0% coverage because tests only called reads/writes directly.
+    val fmt = FlatTypedFormats.flatTypedDefinitionFormat("T1", format1)
+    val original = T1(42)
+    val json = fmt.writes(original)
+    assertResult(Some(original))(fmt.reads(json).asOpt)
+  }
+
+  @Test
+  def flatTypedDefinitionFormat_wrongTypeName_returnsError(): Unit = {
+    val fmt = FlatTypedFormats.flatTypedDefinitionFormat("T1", format1)
+    val jsonForT2 = FlatTypedFormats.flatTypedDefinitionFormat("T2", format2).writes(T2(7))
+    assert(fmt.reads(jsonForT2).isError)
+  }
+
+  @Test
+  def flatTypedDefinitionWrites_modelWithTypeName_throws(): Unit = {
+    // Exercises the require() guard in flatTypedDefinitionWrites: a model whose JSON
+    // serialisation already contains a "typeName" key must be rejected.
+    import play.api.libs.json.JsString
+    import play.api.libs.json.JsObject
+    import play.api.libs.json.OWrites
+
+    // Manually write an OWrites that always produces {"typeName": "collision"}
+    val clashingWrites: OWrites[Unit] = OWrites[Unit](_ => JsObject(Map("typeName" -> JsString("collision"))))
+
+    val writes = FlatTypedFormats.flatTypedDefinitionWrites("T", clashingWrites)
+    intercept[IllegalArgumentException] {
+      writes.writes(())
+    }
+  }
 
 }
 

--- a/courscala/src/test/scala/org/coursera/common/jsonformat/JsonFormatsMapFormatTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/jsonformat/JsonFormatsMapFormatTest.scala
@@ -19,7 +19,7 @@ package org.coursera.common.jsonformat
 import org.coursera.common.stringkey.StringKey
 import org.coursera.common.stringkey.StringKeyFormat
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import play.api.libs.json.Json
 
 class JsonFormatsMapFormatTest extends AssertionsForJUnit {

--- a/courscala/src/test/scala/org/coursera/common/jsonformat/JsonFormatsTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/jsonformat/JsonFormatsTest.scala
@@ -25,12 +25,19 @@ import org.joda.time.DateTimeZone
 import org.joda.time.Duration
 import org.joda.time.Instant
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import play.api.libs.json.Format
+import play.api.libs.json.JsError
+import play.api.libs.json.JsNull
 import play.api.libs.json.JsNumber
+import play.api.libs.json.JsObject
 import play.api.libs.json.JsString
 import play.api.libs.json.JsSuccess
 import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
+import play.api.libs.json.__
 
 class JsonFormatsTest extends AssertionsForJUnit {
 
@@ -49,7 +56,7 @@ class JsonFormatsTest extends AssertionsForJUnit {
   def enums(): Unit = {
     assertResult(Color.Amber)(JsString("Amber").as[Color])
 
-    assertResult(JsString("Green"))(Json.toJson(Color.Green))
+    assertResult(JsString("Green"))(Json.toJson[Color](Color.Green))
   }
 
   @Test
@@ -71,6 +78,154 @@ class JsonFormatsTest extends AssertionsForJUnit {
 
 
   @Test
+  def emptyFormat(): Unit = {
+    val fmt = JsonFormats.emptyFormat(42)
+    assertResult(JsSuccess(42))(fmt.reads(JsNull))
+    assertResult(Json.obj())(fmt.writes(42))
+  }
+
+  @Test
+  def delegateFormat_roundtrip(): Unit = {
+    val fmt = JsonFormats.delegateFormat[TestId, (Int, String)](
+      { case (p1, p2) => TestId(p1, p2) },
+      id => (id.part1, id.part2))
+    val id = TestId(1, "test")
+    assertResult(JsSuccess(id))(fmt.reads(fmt.writes(id)))
+  }
+
+  @Test
+  def delegateOWrites(): Unit = {
+    val innerWrites: OWrites[TestId] = Json.writes[TestId]
+    case class Container(id: TestId)
+    val writes = JsonFormats.delegateOWrites[Container, TestId](_.id)(innerWrites)
+    assertResult(innerWrites.writes(TestId(1, "x")))(writes.writes(Container(TestId(1, "x"))))
+  }
+
+  @Test
+  def delegateOFormat_roundtrip(): Unit = {
+    val innerFmt: OFormat[TestId] = Json.format[TestId]
+    case class Wrapper(inner: TestId)
+    val fmt = JsonFormats.delegateOFormat[Wrapper, TestId](Wrapper.apply, _.inner)(innerFmt)
+    val w = Wrapper(TestId(2, "y"))
+    assertResult(JsSuccess(w))(fmt.reads(fmt.writes(w)))
+  }
+
+  @Test
+  def caseClassOFormat_roundtrip(): Unit = {
+    implicit val idFmt: OFormat[TestId] = Json.format[TestId]
+    case class Outer(id: TestId)
+    val fmt = JsonFormats.caseClassOFormat[Outer, TestId](Outer.apply, Outer.unapply)
+    val o = Outer(TestId(3, "z"))
+    assertResult(JsSuccess(o))(fmt.reads(fmt.writes(o)))
+  }
+
+  @Test
+  def enumerationFormat_reads(): Unit = {
+    val fmt = JsonFormats.enumerationFormat(Weekday)
+    assertResult(JsSuccess(Weekday.Mon))(fmt.reads(JsString("Mon")))
+    assert(fmt.reads(JsString("Invalid")).isError)
+  }
+
+  @Test
+  def enumerationFormat_writes(): Unit = {
+    val fmt = JsonFormats.enumerationFormat(Weekday)
+    assertResult(JsString("Tue"))(fmt.writes(Weekday.Tue))
+  }
+
+  @Test
+  def formatWithDefaults_missingFieldUsesDefault(): Unit = {
+    val fmt = JsonFormats.formatWithDefaults(
+      Json.format[Config],
+      Json.obj("host" -> "localhost"))
+    assertResult(JsSuccess(Config("localhost", 8080)))(fmt.reads(Json.obj("port" -> 8080)))
+  }
+
+  @Test
+  def formatWithDefaults_explicitValueOverridesDefault(): Unit = {
+    val fmt = JsonFormats.formatWithDefaults(
+      Json.format[Config],
+      Json.obj("host" -> "localhost"))
+    assertResult(JsSuccess(Config("example.com", 8080)))(
+      fmt.reads(Json.obj("host" -> "example.com", "port" -> 8080)))
+  }
+
+  @Test
+  def formatWithDefaults_writes(): Unit = {
+    val delegate = Json.format[Config]
+    val fmt = JsonFormats.formatWithDefaults(delegate, Json.obj())
+    assertResult(delegate.writes(Config("h", 1)))(fmt.writes(Config("h", 1)))
+  }
+
+  @Test
+  def optionalReads_presentField(): Unit = {
+    import JsonFormats.Implicits.optionalReads
+    val reads = implicitly[Reads[Option[Int]]]
+    assertResult(JsSuccess(Some(42)))(reads.reads(JsNumber(42)))
+  }
+
+  @Test
+  def optionalReads_invalidField_returnsNone(): Unit = {
+    import JsonFormats.Implicits.optionalReads
+    val reads = implicitly[Reads[Option[Int]]]
+    assertResult(JsSuccess(None))(reads.reads(JsString("not-an-int")))
+  }
+
+  @Test
+  def withRootPath_stripsPath(): Unit = {
+    import JsonFormats.Implicits.ReadsPathMethods
+    val json = Json.obj("a" -> 1, "b" -> 2)
+    val pruned = (__ \ "b").json.prune.withRootPath.reads(json)
+    assertResult(JsSuccess(Json.obj("a" -> 1)))(pruned)
+  }
+
+  @Test
+  def withRootPath_preservesFailure(): Unit = {
+    // Exercises the `otherwise` branch in withRootPath — a failing Reads must pass through as-is.
+    import JsonFormats.Implicits.ReadsPathMethods
+    val failingReads: Reads[Int] = Reads(_ => JsError("always fails")).withRootPath
+    assert(failingReads.reads(Json.obj("x" -> 1)).isError)
+  }
+
+  @Test
+  def mapReads_invalidKeyFails(): Unit = {
+    // Exercises the JsError branch in mapReads when a JSON key cannot be parsed as K.
+    // TestId requires non-empty part2; "~" alone yields an empty second component → None from reads.
+    import JsonFormats.Implicits.mapReads
+    val reads = implicitly[Reads[Map[TestId, Int]]]
+    // JSON keys are strings; "notAnId" won't parse as (Int, String) via TestId's StringKeyFormat
+    val json = Json.obj("notAnId" -> 1)
+    assert(reads.reads(json).isError)
+  }
+
+  @Test
+  def mapFormat_roundtrip(): Unit = {
+    import JsonFormats.Implicits.mapFormat
+    val fmt = implicitly[play.api.libs.json.OFormat[Map[String, Int]]]
+    val m = Map("a" -> 1, "b" -> 2)
+    assertResult(JsSuccess(m))(fmt.reads(fmt.writes(m)))
+  }
+
+  @Test
+  def enumFormat_reads_invalidValue_returnsError(): Unit = {
+    // Exercises the JsError orElse branch in enumFormat.reads (Enum[T] variant) — the
+    // `jsTry(enum.withName(name))` fails and orElse returns JsError.
+    val fmt = JsonFormats.enumFormat(Color)
+    assert(fmt.reads(JsString("Purple")).isError)
+  }
+
+  @Test
+  def extract_matchingJson(): Unit = {
+    val id = TestId(1, "hello")
+    val json = Json.toJson(id)  // uses TestId.format = stringKeyFormat → JsString("1~hello")
+    assertResult(Some(id))(TestId.Extract.unapply(json))
+  }
+
+  @Test
+  def extract_nonMatchingJson(): Unit = {
+    assertResult(None)(TestId.Extract.unapply(JsString("bad")))
+  }
+
+  @Test
   def dateTime(): Unit = {
     import JsonFormats.Implicits.dateTimeFormat
     val testDatetime = new DateTime(2010, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC)
@@ -87,6 +242,7 @@ object JsonFormatsTest {
     implicit val stringKeyFormat: StringKeyFormat[TestId] =
       StringKeyFormat.caseClassFormat((apply _).tupled, unapply)
     implicit val format: Format[TestId] = JsonFormats.stringKeyFormat[TestId]
+    object Extract extends JsonFormats.Extract[TestId]
   }
 
   sealed trait Color extends EnumSymbol
@@ -98,5 +254,12 @@ object JsonFormatsTest {
 
     implicit val format: Format[Color] = JsonFormats.enumFormat(Color)
   }
+
+  object Weekday extends Enumeration {
+    val Mon, Tue, Wed = Value
+  }
+
+  case class Config(host: String, port: Int)
+  implicit val configFormat: OFormat[Config] = Json.format[Config]
 
 }

--- a/courscala/src/test/scala/org/coursera/common/jsonformat/OrFormatsTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/jsonformat/OrFormatsTest.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.common.jsonformat
+
+import org.junit.Test
+import org.scalatestplus.junit.AssertionsForJUnit
+import play.api.libs.json._
+
+class OrFormatsTest extends AssertionsForJUnit {
+
+  import OrFormats._
+  import OrFormatsTest._
+
+  @Test
+  def unimplementedReads_returnsJsError(): Unit = {
+    val reads = OrFormats.unimplementedReads[String]
+    assert(reads.reads(JsString("x")).isError)
+  }
+
+  @Test
+  def unimplementedWrites_throwsUnsupported(): Unit = {
+    val writes = OrFormats.unimplementedWrites[String]
+    intercept[UnsupportedOperationException](writes.writes("x"))
+  }
+
+  @Test
+  def unimplementedOWrites_throwsUnsupported(): Unit = {
+    val writes = OrFormats.unimplementedOWrites[String]
+    intercept[UnsupportedOperationException](writes.writes("x"))
+  }
+
+  @Test
+  def unimplementedFormat_readsReturnsError(): Unit = {
+    val fmt = OrFormats.unimplementedFormat[String]
+    assert(fmt.reads(JsString("x")).isError)
+  }
+
+  @Test
+  def unimplementedFormat_writesThrows(): Unit = {
+    val fmt = OrFormats.unimplementedFormat[String]
+    intercept[UnsupportedOperationException](fmt.writes("x"))
+  }
+
+  @Test
+  def unimplementedOFormat_readsReturnsError(): Unit = {
+    val fmt = OrFormats.unimplementedOFormat[String]
+    assert(fmt.reads(JsString("x")).isError)
+  }
+
+  @Test
+  def orReads_firstSucceeds(): Unit = {
+    val numReads: Reads[Any] = Reads { case JsNumber(n) => JsSuccess(n: Any); case _ => JsError("not a number") }
+    implicit val strReads: Reads[String] = Reads { case JsString(s) => JsSuccess(s); case _ => JsError("not a string") }
+    val combined = numReads.orReads[String]
+    assertResult(JsSuccess(BigDecimal(3): Any))(combined.reads(JsNumber(3)))
+  }
+
+  @Test
+  def orReads_fallsBackToSecond(): Unit = {
+    val numReads: Reads[Any] = Reads { case JsNumber(n) => JsSuccess(n: Any); case _ => JsError("not a number") }
+    implicit val strReads: Reads[String] = Reads { case JsString(s) => JsSuccess(s); case _ => JsError("not a string") }
+    val combined = numReads.orReads[String]
+    assertResult(JsSuccess("hello": Any))(combined.reads(JsString("hello")))
+  }
+
+  @Test
+  def orWrites_dispatchesBySubtype(): Unit = {
+    implicit val numWrites: Writes[NumVal] = Writes(n => JsNumber(n.n))
+    implicit val strWrites: Writes[StrVal] = Writes(s => JsString(s.s))
+    val combined = OrFormats.unimplementedWrites[BaseVal].orWrites[NumVal].orWrites[StrVal]
+    assertResult(JsNumber(42))(combined.writes(NumVal(42)))
+    assertResult(JsString("hi"))(combined.writes(StrVal("hi")))
+  }
+
+  @Test
+  def orOWrites_dispatchesBySubtype(): Unit = {
+    implicit val numWrites: OWrites[NumVal] = OWrites(n => Json.obj("n" -> n.n))
+    implicit val strWrites: OWrites[StrVal] = OWrites(s => Json.obj("s" -> s.s))
+    val combined = OrFormats.unimplementedOWrites[BaseVal].orOWrites[NumVal].orOWrites[StrVal]
+    assertResult(Json.obj("n" -> 42))(combined.writes(NumVal(42)))
+    assertResult(Json.obj("s" -> "hi"))(combined.writes(StrVal("hi")))
+  }
+
+  @Test
+  def orFormat_readsAndWrites(): Unit = {
+    implicit val circleFormat: Format[Circle] = Json.format[Circle]
+    implicit val squareFormat: Format[Square] = Json.format[Square]
+    val combined = OrFormats.unimplementedFormat[Shape].orFormat[Circle].orFormat[Square]
+    val circle: Shape = Circle(5)
+    val square: Shape = Square(3)
+    assertResult(JsSuccess(circle))(combined.reads(combined.writes(circle)))
+    assertResult(JsSuccess(square))(combined.reads(combined.writes(square)))
+  }
+
+  @Test
+  def orOFormat_readsAndWrites(): Unit = {
+    implicit val circleFormat: OFormat[Circle] = Json.format[Circle]
+    implicit val squareFormat: OFormat[Square] = Json.format[Square]
+    val combined = OrFormats.unimplementedOFormat[Shape].orOFormat[Circle].orOFormat[Square]
+    val circle: Shape = Circle(5)
+    val square: Shape = Square(3)
+    assertResult(JsSuccess(circle))(combined.reads(combined.writes(circle)))
+    assertResult(JsSuccess(square))(combined.reads(combined.writes(square)))
+  }
+}
+
+object OrFormatsTest {
+  sealed trait BaseVal
+  case class NumVal(n: Int) extends BaseVal
+  case class StrVal(s: String) extends BaseVal
+
+  sealed trait Shape
+  case class Circle(radius: Int) extends Shape
+  case class Square(side: Int) extends Shape
+}

--- a/courscala/src/test/scala/org/coursera/common/jsonformat/RequiringFormatsTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/jsonformat/RequiringFormatsTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.common.jsonformat
+
+import org.junit.Test
+import org.scalatestplus.junit.AssertionsForJUnit
+import play.api.libs.json._
+
+class RequiringFormatsTest extends AssertionsForJUnit {
+
+  import RequiringFormatsTest._
+
+  @Test
+  def requiringReads_success(): Unit = {
+    val reads = RequiringFormats.requiringReads(positiveFormat)
+    assertResult(JsSuccess(Positive(1)))(reads.reads(Json.obj("value" -> 1)))
+  }
+
+  @Test
+  def requiringReads_illegalArgument_returnsJsError(): Unit = {
+    val reads = RequiringFormats.requiringReads(positiveFormat)
+    assert(reads.reads(Json.obj("value" -> -1)).isError)
+  }
+
+  @Test
+  def requiringFormat_roundtrip(): Unit = {
+    val fmt = RequiringFormats.requiringFormat(positiveFormat)
+    assertResult(JsSuccess(Positive(5)))(fmt.reads(fmt.writes(Positive(5))))
+  }
+
+  @Test
+  def requiringFormat_invalidReturnsError(): Unit = {
+    val fmt = RequiringFormats.requiringFormat(positiveFormat)
+    assert(fmt.reads(Json.obj("value" -> 0)).isError)
+  }
+
+  @Test
+  def requiringOFormat_roundtrip(): Unit = {
+    val fmt = RequiringFormats.requiringOFormat(positiveFormat)
+    assertResult(JsSuccess(Positive(7)))(fmt.reads(fmt.writes(Positive(7))))
+  }
+
+  @Test
+  def requiringOFormat_invalidReturnsError(): Unit = {
+    val fmt = RequiringFormats.requiringOFormat(positiveFormat)
+    assert(fmt.reads(Json.obj("value" -> 0)).isError)
+  }
+}
+
+object RequiringFormatsTest {
+  case class Positive(value: Int) {
+    require(value > 0, "value must be positive")
+  }
+
+  implicit val positiveFormat: OFormat[Positive] = Json.format[Positive]
+}

--- a/courscala/src/test/scala/org/coursera/common/jsonformat/TypedFormatsTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/jsonformat/TypedFormatsTest.scala
@@ -17,7 +17,7 @@
 package org.coursera.common.jsonformat
 
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
@@ -46,6 +46,23 @@ class TypedFormatsTest extends AssertionsForJUnit {
       "definition" -> Json.obj("a" -> 1))
 
     assertResult(expectedJs)(writes.writes(T1(1)))
+  }
+
+  @Test
+  def typedDefinitionFormat_roundtrip(): Unit = {
+    // Exercises the combined OFormat entry point (typedDefinitionFormat) which was
+    // previously at 0% coverage because tests only called reads/writes directly.
+    val fmt = TypedFormats.typedDefinitionFormat("T1", format1)
+    val original = T1(99)
+    val json = fmt.writes(original)
+    assertResult(Some(original))(fmt.reads(json).asOpt)
+  }
+
+  @Test
+  def typedDefinitionFormat_wrongTypeName_returnsError(): Unit = {
+    val fmt = TypedFormats.typedDefinitionFormat("T1", format1)
+    val jsonForT2 = TypedFormats.typedDefinitionFormat("T2", format2).writes(T2(5))
+    assert(fmt.reads(jsonForT2).isError)
   }
 
 }

--- a/courscala/src/test/scala/org/coursera/common/reflect/CompanionReflectorTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/reflect/CompanionReflectorTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.common.reflect
+
+import org.junit.Test
+import org.scalatestplus.junit.AssertionsForJUnit
+
+class CompanionReflectorTest extends AssertionsForJUnit {
+
+  import CompanionReflectorTest._
+
+  /**
+   * findCompanionClassOfScalaClass: given the Scala class (not the companion `$` class),
+   * locate the companion object's class. This path was previously 0% covered.
+   */
+  @Test
+  def findCompanionClassOfScalaClass_returnsCompanionClass(): Unit = {
+    val companionClass =
+      CompanionReflector.findCompanionClassOfScalaClass[Widget.type](classOf[Widget])
+    // The companion object singleton lives in Widget$
+    assert(companionClass.getName.endsWith("Widget$"))
+  }
+
+  /**
+   * findCompanionInstanceOfScalaClass: given the Scala class, find and return the
+   * live companion object instance. This path was previously 0% covered.
+   */
+  @Test
+  def findCompanionInstanceOfScalaClass_returnsInstance(): Unit = {
+    val instance =
+      CompanionReflector.findCompanionInstanceOfScalaClass[Widget.type](classOf[Widget])
+    // The returned instance must be the same singleton as Widget
+    assertResult(Widget)(instance)
+  }
+
+  /**
+   * Verify that findCompanionClassOfScalaClass throws when no companion exists.
+   */
+  @Test
+  def findCompanionClassOfScalaClass_noCompanion_throws(): Unit = {
+    intercept[ClassNotFoundException] {
+      CompanionReflector.findCompanionClassOfScalaClass[Any](classOf[NoCompanion])
+    }
+  }
+}
+
+object CompanionReflectorTest {
+
+  /** A plain case class with a companion object — the companion class is Widget$. */
+  case class Widget(id: Int)
+
+  object Widget {
+    val label: String = "widget"
+  }
+
+  /** A class with no companion object — used to test the ClassNotFoundException path. */
+  class NoCompanion(val x: Int)
+}

--- a/courscala/src/test/scala/org/coursera/common/stringkey/StringKeyFormatTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/stringkey/StringKeyFormatTest.scala
@@ -20,8 +20,13 @@ import java.util.UUID
 
 import org.coursera.common.collection.Enum
 import org.coursera.common.collection.EnumSymbol
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.Instant
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
+
+import scala.collection.immutable
 
 class StringKeyFormatTest extends AssertionsForJUnit {
 
@@ -188,6 +193,242 @@ class StringKeyFormatTest extends AssertionsForJUnit {
       StringKey.stringify(new TestId("aBaC9"))
     }
   }
+
+  @Test
+  def intFormat_roundtrip(): Unit = {
+    assertResult(Some(42))(StringKey("42").asOpt[Int])
+    assertResult(StringKey("42"))(StringKey.toStringKey(42))
+    assertResult(None)(StringKey("notanint").asOpt[Int])
+  }
+
+  @Test
+  def longFormat_roundtrip(): Unit = {
+    assertResult(Some(123456789012345L))(StringKey("123456789012345").asOpt[Long])
+    assertResult(StringKey("123456789012345"))(StringKey.toStringKey(123456789012345L))
+    assertResult(None)(StringKey("notalong").asOpt[Long])
+  }
+
+  @Test
+  def booleanFormat_roundtrip(): Unit = {
+    assertResult(Some(true))(StringKey("true").asOpt[Boolean])
+    assertResult(Some(false))(StringKey("false").asOpt[Boolean])
+    assertResult(StringKey("true"))(StringKey.toStringKey(true))
+    assertResult(None)(StringKey("yes").asOpt[Boolean])
+  }
+
+  @Test
+  def doubleFormat_roundtrip(): Unit = {
+    assertResult(Some(3.14))(StringKey("3.14").asOpt[Double])
+    assertResult(StringKey("3.14"))(StringKey.toStringKey(3.14))
+    assertResult(None)(StringKey("notadouble").asOpt[Double])
+  }
+
+  @Test
+  def floatFormat_roundtrip(): Unit = {
+    assertResult(Some(1.5f))(StringKey("1.5").asOpt[Float])
+    assertResult(StringKey("1.5"))(StringKey.toStringKey(1.5f))
+  }
+
+  @Test
+  def shortFormat_roundtrip(): Unit = {
+    assertResult(Some(7.toShort))(StringKey("7").asOpt[Short])
+    assertResult(StringKey("7"))(StringKey.toStringKey(7.toShort))
+    assertResult(None)(StringKey("99999999").asOpt[Short])
+  }
+
+  @Test
+  def dateTimeFormat_roundtrip(): Unit = {
+    val millis = 1592217600000L
+    val dt = new DateTime(millis)
+    val key = StringKey.toStringKey(dt)
+    assertResult(millis)(key.asOpt[DateTime].get.getMillis)
+  }
+
+  @Test
+  def instantFormat_roundtrip(): Unit = {
+    val instant = new Instant(1592222400000L)
+    val key = StringKey.toStringKey(instant)
+    assertResult(Some(instant))(key.asOpt[Instant])
+  }
+
+  @Test
+  def seqFormat_roundtrip(): Unit = {
+    val fmt = implicitly[StringKeyFormat[immutable.Seq[Int]]]
+    assertResult(StringKey("1,2,3"))(fmt.writes(immutable.Seq(1, 2, 3)))
+    assertResult(Some(immutable.Seq(1, 2, 3)))(fmt.reads(StringKey("1,2,3")))
+  }
+
+  @Test
+  def seqFormat_empty(): Unit = {
+    val fmt = implicitly[StringKeyFormat[immutable.Seq[Int]]]
+    assertResult(Some(immutable.Seq.empty[Int]))(fmt.reads(StringKey("")))
+    assertResult(StringKey(""))(fmt.writes(immutable.Seq.empty))
+  }
+
+  @Test
+  def seqFormat_escapedSeparator(): Unit = {
+    val fmt = implicitly[StringKeyFormat[immutable.Seq[String]]]
+    val items = immutable.Seq("a,b", "c")
+    val key = fmt.writes(items)
+    assertResult(Some(items))(fmt.reads(key))
+  }
+
+  @Test
+  def setFormat_roundtrip(): Unit = {
+    val fmt = implicitly[StringKeyFormat[Set[Int]]]
+    assertResult(Some(Set(1, 2, 3)))(fmt.reads(StringKey("1,2,3")))
+  }
+
+  @Test
+  def setFormat_empty(): Unit = {
+    val fmt = implicitly[StringKeyFormat[Set[Int]]]
+    assertResult(Some(Set.empty[Int]))(fmt.reads(StringKey("")))
+    assertResult(StringKey(""))(fmt.writes(Set.empty))
+  }
+
+  @Test
+  def setFormat_writtenSorted(): Unit = {
+    val fmt = implicitly[StringKeyFormat[Set[String]]]
+    assertResult(StringKey("a,b,c"))(fmt.writes(Set("c", "a", "b")))
+  }
+
+  @Test
+  def delegateFormat_roundtrip(): Unit = {
+    val fmt = StringKeyFormat.delegateFormat[Int, String](
+      s => scala.util.Try(s.toInt).toOption,
+      _.toString)
+    assertResult(Some(42))(fmt.reads(StringKey("42")))
+    assertResult(StringKey("42"))(fmt.writes(42))
+    assertResult(None)(fmt.reads(StringKey("bad")))
+  }
+
+  @Test
+  def enumerationFormat_roundtrip(): Unit = {
+    val fmt = StringKeyFormat.enumerationFormat(Weekday)
+    assertResult(Some(Weekday.Mon))(fmt.reads(StringKey("Mon")))
+    assertResult(StringKey("Tue"))(fmt.writes(Weekday.Tue))
+    assertResult(None)(fmt.reads(StringKey("Invalid")))
+  }
+
+  @Test
+  def typedEmptyStringFormat_roundtrip(): Unit = {
+    val fmt = StringKeyFormat.typedEmptyStringFormat("marker", "canonical")
+    assertResult(Some("canonical"))(fmt.reads(StringKey("marker")))
+    assertResult(StringKey("marker"))(fmt.writes("canonical"))
+    assertResult(None)(fmt.reads(StringKey("wrong")))
+  }
+
+  @Test
+  def typedCaseFormat_roundtrip(): Unit = {
+    val fmt = StringKeyFormat.typedCaseFormat[TestId, String]("testid", TestId.apply, TestId.unapply)
+    val id = new TestId("abc")
+    val key = fmt.writes(id)
+    assertResult(Some(id))(fmt.reads(key))
+    assertResult(None)(fmt.reads(StringKey("wrong~abc")))
+  }
+
+  @Test
+  def unimplementedFormat_readsReturnsNone(): Unit = {
+    val fmt = StringKeyFormat.unimplementedFormat[Int]
+    assertResult(None)(fmt.reads(StringKey("anything")))
+  }
+
+  @Test
+  def unimplementedFormat_writesThrows(): Unit = {
+    val fmt = StringKeyFormat.unimplementedFormat[Int]
+    intercept[UnsupportedOperationException](fmt.writes(1))
+  }
+
+  @Test
+  def orFormat_combinesFormats(): Unit = {
+    import StringKeyFormat.Implicits._
+    // Only matches key "special" → "SPECIAL", returns None for anything else
+    val specialFormat = StringKeyFormat.typedEmptyStringFormat[String]("special", "SPECIAL")
+    val baseFormat = implicitly[StringKeyFormat[String]]
+    // Pass uFormat explicitly to avoid ambient implicit ambiguity
+    val combined = baseFormat.orFormat[String](specialFormat, scala.reflect.classTag[String])
+    assertResult(Some("SPECIAL"))(combined.reads(StringKey("special")))
+    assertResult(Some("other"))(combined.reads(StringKey("other")))
+  }
+
+  @Test
+  def orFormat_writes_nonUSubtype_delegatesToBase(): Unit = {
+    // Exercises the `case _ => baseFormat.writes(obj)` branch in OrFormat.writes.
+    // Shape is a sealed trait; Circle is U <: Shape; Square is another subtype of Shape.
+    // When writes is called with a Square (not a Circle), it must fall through to baseFormat.
+    import StringKeyFormat.Implicits._
+    import StringKeyFormatTest.ShapeFormats._
+
+    val combined: StringKeyFormat[Shape] =
+      squareFormat.orFormat[Circle](circleFormat, scala.reflect.classTag[Circle])
+
+    // writes(Circle) → Circle matches `case u: Circle` → uFormat used
+    assertResult(StringKey("circle:5"))(combined.writes(Circle(5)))
+
+    // writes(Square) → Square is not a Circle → falls through to baseFormat.writes
+    assertResult(StringKey("square:3"))(combined.writes(Square(3)))
+  }
+
+  @Test
+  def seqFormat_elementParseFailure_returnsNone(): Unit = {
+    // Exercises the `case "" => None` (empty-item) branch in SeqFormat.reads.
+    val fmt = implicitly[StringKeyFormat[immutable.Seq[Int]]]
+    // "1,,3" splits into ["1", "", "3"]; the empty string becomes None → whole result is None
+    assertResult(None)(fmt.reads(StringKey("1,,3")))
+  }
+
+  @Test
+  def seqFormat_invalidElement_returnsNone(): Unit = {
+    // Exercises format.reads returning None for a non-empty but unparseable item.
+    val fmt = implicitly[StringKeyFormat[immutable.Seq[Int]]]
+    assertResult(None)(fmt.reads(StringKey("1,notanint,3")))
+  }
+
+  @Test
+  def setFormat_invalidElement_returnsNone(): Unit = {
+    // Exercises the failure branch in SetFormat.reads when an element cannot be parsed.
+    val fmt = implicitly[StringKeyFormat[Set[Int]]]
+    assertResult(None)(fmt.reads(StringKey("1,notanint,3")))
+  }
+
+  @Test
+  def setFormat_emptyItem_returnsNone(): Unit = {
+    // Exercises the `case "" => None` branch in SetFormat.reads.
+    val fmt = implicitly[StringKeyFormat[Set[Int]]]
+    assertResult(None)(fmt.reads(StringKey("1,,3")))
+  }
+
+  @Test
+  @deprecated("tests deprecated StringKey.unapply to keep coverage", "2017-04-05")
+  def stringKey_unapply_deprecated(): Unit = {
+    // Exercises the deprecated StringKey.unapply extractor (0% coverage before).
+    val Some(key) = StringKey.unapply("hello")
+    assertResult(StringKey("hello"))(key)
+  }
+
+  @Test
+  @deprecated("tests deprecated StringKey.apply[T] to keep coverage", "2017-04-05")
+  def stringKey_apply_deprecated(): Unit = {
+    // Exercises the deprecated StringKey.apply[T: StringKeyFormat](t: T) overload (0% coverage).
+    val key = StringKey[Int](42)
+    assertResult(StringKey("42"))(key)
+  }
+
+  @Test
+  def uuidFormat_reads_wrongLengthBase64_returnsNone(): Unit = {
+    // Exercises the `require(bytes.length == 16)` guard in UuidFormat.reads: a valid base64
+    // string that decodes to fewer than 16 bytes must return None.
+    import java.util.Base64
+    val shortBytes  = Base64.getUrlEncoder.withoutPadding().encodeToString(Array[Byte](1, 2, 3))
+    assertResult(None)(StringKey(shortBytes).asOpt[java.util.UUID])
+  }
+
+  @Test
+  def enumFormat_writes_serialisesName(): Unit = {
+    // Exercises the `v => StringKey(v.name)` writes lambda in StringKeyFormat.enumFormat.
+    val fmt = StringKeyFormat.enumFormat(Color)
+    assertResult(StringKey("Green"))(fmt.writes(Color.Green))
+  }
 }
 
 object StringKeyFormatTest {
@@ -214,6 +455,37 @@ object StringKeyFormatTest {
 
   object TestId {
     implicit val stringKeyFormat: StringKeyFormat[TestId] = StringKeyFormat.caseClassFormat(apply, unapply)
+  }
+
+  object Weekday extends Enumeration {
+    val Mon, Tue, Wed = Value
+  }
+
+  // ─── Hierarchy used to test OrFormat.writes non-U branch ───────────────────
+
+  object ShapeFormats {
+    sealed trait Shape
+    case class Circle(radius: Int) extends Shape
+    case class Square(side: Int)   extends Shape
+
+    val circleFormat: StringKeyFormat[Circle] = StringKeyFormat(
+      sk => sk.key match {
+        case s if s.startsWith("circle:") => scala.util.Try(s.drop(7).toInt).toOption.map(Circle.apply)
+        case _ => None
+      },
+      c => StringKey(s"circle:${c.radius}")
+    )
+
+    val squareFormat: StringKeyFormat[Shape] = StringKeyFormat(
+      sk => sk.key match {
+        case s if s.startsWith("square:") => scala.util.Try(s.drop(7).toInt).toOption.map(Square.apply)
+        case _ => None
+      },
+      {
+        case Square(s) => StringKey(s"square:$s")
+        case Circle(r) => StringKey(s"circle:$r")
+      }
+    )
   }
 
 }

--- a/courscala/src/test/scala/org/coursera/common/stringkey/TupleFormatsTest.scala
+++ b/courscala/src/test/scala/org/coursera/common/stringkey/TupleFormatsTest.scala
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2024 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.common.stringkey
+
+import org.junit.Test
+import org.scalatestplus.junit.AssertionsForJUnit
+
+/**
+ * Roundtrip read/write tests for [[TupleFormats]] arities 4 through 22.
+ *
+ * Arities 2 and 3 are already covered by [[StringKeyFormatTest]].
+ * This file covers the remaining generated formats to bring code coverage
+ * of TupleFormats.scala close to 100%.
+ */
+class TupleFormatsTest extends AssertionsForJUnit {
+
+  import TupleFormatsTest._
+
+  // ─── Tuple4 ────────────────────────────────────────────────────────────────
+
+  @Test def tuple4_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d")
+    val key = format4.writes(data)
+    assertResult(Some(data))(format4.reads(key))
+  }
+
+  @Test def tuple4_key_containsSeparators(): Unit = {
+    val data = ("1", "2", "3", "4")
+    assertResult(s"1${SEP}2${SEP}3${SEP}4")(format4.writes(data).key)
+  }
+
+  @Test def tuple4_read_badArity_returnsNone(): Unit = {
+    assertResult(None)(format4.reads(StringKey(s"a${SEP}b${SEP}c")))
+  }
+
+  // ─── Tuple5 ────────────────────────────────────────────────────────────────
+
+  @Test def tuple5_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e")
+    val key = format5.writes(data)
+    assertResult(Some(data))(format5.reads(key))
+  }
+
+  @Test def tuple5_key_containsSeparators(): Unit = {
+    val data = ("1", "2", "3", "4", "5")
+    assertResult(s"1${SEP}2${SEP}3${SEP}4${SEP}5")(format5.writes(data).key)
+  }
+
+  // ─── Tuple6 ────────────────────────────────────────────────────────────────
+
+  @Test def tuple6_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f")
+    val key = format6.writes(data)
+    assertResult(Some(data))(format6.reads(key))
+  }
+
+  @Test def tuple6_key_containsSeparators(): Unit = {
+    val data = ("1", "2", "3", "4", "5", "6")
+    assertResult(s"1${SEP}2${SEP}3${SEP}4${SEP}5${SEP}6")(format6.writes(data).key)
+  }
+
+  // ─── Tuple7 ────────────────────────────────────────────────────────────────
+
+  @Test def tuple7_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g")
+    val key = format7.writes(data)
+    assertResult(Some(data))(format7.reads(key))
+  }
+
+  @Test def tuple7_key_containsSeparators(): Unit = {
+    val data = ("1", "2", "3", "4", "5", "6", "7")
+    assertResult(s"1${SEP}2${SEP}3${SEP}4${SEP}5${SEP}6${SEP}7")(format7.writes(data).key)
+  }
+
+  // ─── Tuple8 ────────────────────────────────────────────────────────────────
+
+  @Test def tuple8_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h")
+    val key = format8.writes(data)
+    assertResult(Some(data))(format8.reads(key))
+  }
+
+  @Test def tuple8_key_containsSeparators(): Unit = {
+    val data = ("1", "2", "3", "4", "5", "6", "7", "8")
+    assertResult(s"1${SEP}2${SEP}3${SEP}4${SEP}5${SEP}6${SEP}7${SEP}8")(format8.writes(data).key)
+  }
+
+  // ─── Tuple9 ────────────────────────────────────────────────────────────────
+
+  @Test def tuple9_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i")
+    val key = format9.writes(data)
+    assertResult(Some(data))(format9.reads(key))
+  }
+
+  // ─── Tuple10 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple10_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+    val key = format10.writes(data)
+    assertResult(Some(data))(format10.reads(key))
+  }
+
+  // ─── Tuple11 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple11_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
+    val key = format11.writes(data)
+    assertResult(Some(data))(format11.reads(key))
+  }
+
+  // ─── Tuple12 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple12_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l")
+    val key = format12.writes(data)
+    assertResult(Some(data))(format12.reads(key))
+  }
+
+  // ─── Tuple13 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple13_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m")
+    val key = format13.writes(data)
+    assertResult(Some(data))(format13.reads(key))
+  }
+
+  // ─── Tuple14 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple14_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n")
+    val key = format14.writes(data)
+    assertResult(Some(data))(format14.reads(key))
+  }
+
+  // ─── Tuple15 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple15_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o")
+    val key = format15.writes(data)
+    assertResult(Some(data))(format15.reads(key))
+  }
+
+  // ─── Tuple16 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple16_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p")
+    val key = format16.writes(data)
+    assertResult(Some(data))(format16.reads(key))
+  }
+
+  // ─── Tuple17 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple17_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q")
+    val key = format17.writes(data)
+    assertResult(Some(data))(format17.reads(key))
+  }
+
+  // ─── Tuple18 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple18_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r")
+    val key = format18.writes(data)
+    assertResult(Some(data))(format18.reads(key))
+  }
+
+  // ─── Tuple19 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple19_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s")
+    val key = format19.writes(data)
+    assertResult(Some(data))(format19.reads(key))
+  }
+
+  // ─── Tuple20 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple20_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t")
+    val key = format20.writes(data)
+    assertResult(Some(data))(format20.reads(key))
+  }
+
+  // ─── Tuple21 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple21_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u")
+    val key = format21.writes(data)
+    assertResult(Some(data))(format21.reads(key))
+  }
+
+  // ─── Tuple22 ───────────────────────────────────────────────────────────────
+
+  @Test def tuple22_writeAndRead_roundtrip(): Unit = {
+    val data = ("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v")
+    val key = format22.writes(data)
+    assertResult(Some(data))(format22.reads(key))
+  }
+
+  @Test def tuple22_key_containsSeparators(): Unit = {
+    val data = ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22")
+    val key = format22.writes(data)
+    assertResult(s"1${SEP}2${SEP}3${SEP}4${SEP}5${SEP}6${SEP}7${SEP}8${SEP}9${SEP}10${SEP}11${SEP}12${SEP}13${SEP}14${SEP}15${SEP}16${SEP}17${SEP}18${SEP}19${SEP}20${SEP}21${SEP}22")(key.key)
+  }
+
+  // ─── Separator escaping (verify consistency with Tuple4) ───────────────────
+
+  @Test def tuple4_withEscapedSeparatorInValue_roundtrips(): Unit = {
+    val data = (s"a${SEP}b", "c", "d", "e")
+    val key = format4.writes(data)
+    assertResult(Some(data))(format4.reads(key))
+  }
+
+  // ─── Bad-arity reads return None ───────────────────────────────────────────
+
+  @Test def tuple5_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format5.reads(StringKey(s"a${SEP}b${SEP}c${SEP}d")))
+  }
+
+  @Test def tuple10_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format10.reads(StringKey(s"a${SEP}b")))
+  }
+
+  // ─── Bad-arity reads return None for remaining arities ─────────────────────
+  // Each TupleNFormat has a branch: Array(N parts) vs _ => None.
+  // The `_ => None` path was 0% for arities 3, 6–9, 11–22.
+
+  @Test def tuple3_read_tooFewSegments_returnsNone(): Unit = {
+    // Arities 2 and 3 live in StringKeyFormatTest; this covers the Tuple3 `_ => None` branch.
+    val fmt3 = implicitly[StringKeyFormat[(String, String, String)]]
+    assertResult(None)(fmt3.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple6_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format6.reads(StringKey(s"a${SEP}b${SEP}c")))
+  }
+
+  @Test def tuple7_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format7.reads(StringKey(s"a${SEP}b${SEP}c")))
+  }
+
+  @Test def tuple8_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format8.reads(StringKey(s"a${SEP}b${SEP}c")))
+  }
+
+  @Test def tuple9_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format9.reads(StringKey(s"a${SEP}b${SEP}c")))
+  }
+
+  @Test def tuple11_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format11.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple12_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format12.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple13_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format13.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple14_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format14.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple15_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format15.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple16_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format16.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple17_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format17.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple18_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format18.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple19_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format19.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple20_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format20.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple21_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format21.reads(StringKey(s"a${SEP}b")))
+  }
+
+  @Test def tuple22_read_tooFewSegments_returnsNone(): Unit = {
+    assertResult(None)(format22.reads(StringKey(s"a${SEP}b")))
+  }
+}
+
+object TupleFormatsTest {
+
+  val SEP = "~"
+
+  val format4  = implicitly[StringKeyFormat[(String, String, String, String)]]
+  val format5  = implicitly[StringKeyFormat[(String, String, String, String, String)]]
+  val format6  = implicitly[StringKeyFormat[(String, String, String, String, String, String)]]
+  val format7  = implicitly[StringKeyFormat[(String, String, String, String, String, String, String)]]
+  val format8  = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String)]]
+  val format9  = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String)]]
+  val format10 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String)]]
+  val format11 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String)]]
+  val format12 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format13 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format14 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format15 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format16 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format17 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format18 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format19 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format20 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format21 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+  val format22 = implicitly[StringKeyFormat[(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String)]]
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,7 +44,8 @@ object Dependencies {
   }
 
   object ScalatestPlusJUnit {
-    val scalatestPlusJunit = "org.scalatestplus" %% "junit-4-13" % "3.2.19.0" % "test"
+    val version = "3.2.19.0"
+    val scalatestPlusJunit = "org.scalatestplus" %% "junit-4-13" % version % "test"
   }
 
   object JUnitInterface {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,8 +39,12 @@ object Dependencies {
   }
 
   object Scalatest {
-    val version = "3.0.4"
+    val version = "3.2.19"
     val scalatest = "org.scalatest" %% "scalatest" % version % "test"
+  }
+
+  object ScalatestPlusJUnit {
+    val scalatestPlusJunit = "org.scalatestplus" %% "junit-4-13" % "3.2.19.0" % "test"
   }
 
   object JUnitInterface {


### PR DESCRIPTION
## Summary

Pure test additions — **no production code changes**.

Upgrade test dependencies and add new test files to improve coverage before the Scala 2.13 migration (PR #24).

### Changes

**Build (test scope only):**
- Scalatest 3.0.4 → 3.2.19
- Added `scalatestplus-junit 3.2.19.0`
- Migrated existing test imports: `org.scalatest.junit` → `org.scalatestplus.junit`

**5 new test files:**
| File | What it covers |
|------|----------------|
| `OrFormatsTest` | `OrFormats` — previously 0% covered |
| `RequiringFormatsTest` | `RequiringFormats` — previously 0% covered |
| `FutureExtractorsTest` | `Futures.Extract` arities 4–22 — previously 0% covered |
| `TupleFormatsTest` | `TupleFormats` arities 4–22 — previously 0% covered |
| `CompanionReflectorTest` | `CompanionReflector` — previously 0% covered |

**8 existing test files expanded** with additional cases.

### Coverage

| | Tests |
|---|---|
| Before | 9 |
| After | **196** |
| Δ | +187 |

## Review order

Merge this PR first, then review [#24](https://github.com/coursera/courscala/pull/24) (Scala 2.13 migration). PR #24 is rebased on this branch so its diff shows only migration changes.